### PR TITLE
Implement workaround for gif not showing in reply embed

### DIFF
--- a/src/main/java/dev/kurumiDisciples/chisataki/commands/slash/GifCommand.java
+++ b/src/main/java/dev/kurumiDisciples/chisataki/commands/slash/GifCommand.java
@@ -31,6 +31,6 @@ public class GifCommand extends SlashCommand {
 	@Override
 	public void execute(SlashCommandInteractionEvent event) {
 		event.deferReply().queue();
-		event.getHook().editOriginal("").setEmbeds(getRandomGif()).queue();
+		event.getHook().sendMessage("").setEmbeds(getRandomGif()).queue();
 	}
 }


### PR DESCRIPTION
I noticed gifs would not render on embeds. I reached out to the JDA server and they say it's a discord use. While `editOriginal` does not work, `sendMessage` seems to fix the issue